### PR TITLE
Darken link colour to make it more legible.

### DIFF
--- a/_sass/base/_elements.scss
+++ b/_sass/base/_elements.scss
@@ -99,7 +99,7 @@ em {
 
 
 a {
-    color: $yellow;
+    color: darken($yellow, 10%);
     border-bottom: 1px solid rgba(255, 168, 0, 0.1);
     @include transition(border-bottom-color ease .3s);
     text-decoration: none;


### PR DESCRIPTION
Change the link colour to #CC8600, which is 10% darker than our base yellow of #FFA800.  This makes our thin font way easier to read.

Closes #8.

Old:

![](https://kibako-dev.s3.amazonaws.com/kibako/7434CF6E-4FC4-445A-BA90-6DEF6CF32DF0/ScreenShot2015-07-29at11.17.14.png)

New:

![](https://kibako-dev.s3.amazonaws.com/kibako/A61CB081-9D72-47D3-9242-92ECABFEAA86/ScreenShot2015-07-29at11.13.23.png)
