### PR TITLE
Fixes 12: Add clear naming convention for tags

### DIFF
--- a/_posts/tools/2015-02-13-branches.md
+++ b/_posts/tools/2015-02-13-branches.md
@@ -12,6 +12,8 @@ We use [Vincent Driessen's Git branching model](http://nvie.com/posts/a-successf
 
   We use `master` as our main branch. This is the branch that is deployed to production environments. Code should only be merged into the `master` branch as part of a production deployment, once it has been finished, reviewed, tested internally and externally, and approved for release.
 
+  While we typically deploy from HEAD of master, we should always make sure that the version that is being deployed is tagged.  See the 'Release branches' and 'Tags' section.
+
 - Next release branch
 
   Our next release branch is `develop`. Code is merged into this branch after a code review. Our staging environments usually contain the code from the `develop` branch.
@@ -26,6 +28,9 @@ We use [Vincent Driessen's Git branching model](http://nvie.com/posts/a-successf
 
 - Hotfix branches
 
-  We only use hotfix branches when working on critical problems that are found on production environments and do not have time to go through the proper QA process. Hotfix branches are created from `master` and merged back into `master`. The naming scheme used is `hotfix/<version>` where the version number follows the same conventions as for the release branches.
+  We only use hotfix branches when working on critical problems that are found on production environments.  A pull request should still be created and reviewed before being deployed. Hotfix branches are created from `master` and merged back into `master`. The naming scheme is similar to the approach used for feature branches except that the branch name is prepended by `hotfix/`, e.g. `hotfix/MB-11-incorrect-colour`.
 
-In practice, we use [git-flow](https://github.com/nvie/gitflow) to manage the branching model, with the exception of finishing feature branches, which is done through pull requests in our repository hosting service.
+  Once the hotfix is complete, please make sure that you also create a new tag for a release before deploying.  This is so we can always be sure what code has been deployed to the site as it's not obvious when looking through tags if `MB-11-incorrect-colour` is a previous release or not.   Without this it would be hard to know what to rollback to.
+
+
+In practice, we use [git-flow](https://github.com/nvie/gitflow) to manage the branching model.

--- a/_posts/tools/2015-11-13-tags.md
+++ b/_posts/tools/2015-11-13-tags.md
@@ -1,0 +1,16 @@
+---
+title: Tags
+permalink: tools/tags
+layout: tools
+categories: tools
+active: tools
+---
+
+When finishing a hotfix or a release, git flow will automatically create a tag. Once named it will also ask for a tag message.  We recommend this message to be a list of tickets and summaries of changes between the last tag and now, e.g.
+
+    MB-123: Summary of the issue
+    MB-124: Summary of the issue
+    MB-125: Summary of the issue
+    MB-126: Summary of the issue
+
+If you're tagging a release manually, then please do so in the same way as you would have when creating a release branch, i.e. `yyyy.mm.dd`. If making more than one release on the same day, append a `-n` to the release version, for example `release/2014.02.13-2`.


### PR DESCRIPTION
- Added new tag page
- Updated release branch section to mention tagging
- Made it clear in the hotfix section that we a tag should always be added manually afterwards prior to deployment.
